### PR TITLE
Fixed another misspelling of "undefined"

### DIFF
--- a/js/jquery.pagedown-bootstrap.js
+++ b/js/jquery.pagedown-bootstrap.js
@@ -48,7 +48,7 @@
 			for(var i in settings.hooks)
 			{
 				var hook = settings.hooks[i];
-				if(typeof hook !== 'object' || typeof hook.event === 'underfined' 
+				if(typeof hook !== 'object' || typeof hook.event === 'undefined' 
 						|| typeof hook.callback !== 'function')
 				{
 					//A bad hook object was given


### PR DESCRIPTION
Noticed a recent commit fixed it in the combined .js files, but not the source .js.
