### PR TITLE
Change toolbar buttons from type "submit" (the default) to "button"

### DIFF
--- a/js/Markdown.Editor.js
+++ b/js/Markdown.Editor.js
@@ -1349,6 +1349,7 @@
 				button.id = id + postfix;
 				button.appendChild(buttonImage);
 				button.title = title;
+				button.type = 'button';
 				$(button).tooltip({placement: 'bottom', container: 'body'})
 				if (textOp)
 					button.textOp = textOp;

--- a/js/jquery.pagedown-bootstrap.combined.js
+++ b/js/jquery.pagedown-bootstrap.combined.js
@@ -2694,7 +2694,7 @@ else
 				button.id = id + postfix;
 				button.appendChild(buttonImage);
 				button.title = title;
-				button.type = 'button'
+				button.type = 'button';
 				$(button).tooltip({placement: 'bottom', container: 'body'})
 				if (textOp)
 					button.textOp = textOp;

--- a/js/jquery.pagedown-bootstrap.combined.js
+++ b/js/jquery.pagedown-bootstrap.combined.js
@@ -2694,6 +2694,7 @@ else
 				button.id = id + postfix;
 				button.appendChild(buttonImage);
 				button.title = title;
+				button.type = 'button'
 				$(button).tooltip({placement: 'bottom', container: 'body'})
 				if (textOp)
 					button.textOp = textOp;


### PR DESCRIPTION
This solves a problem when the pagedown is part of a form.
Currently when pressing enter inside another textbox (`<input type="text" />`) it will cause the first button in the pagedown plugin to be clicked.
